### PR TITLE
add prop to disable detect user country code from connected IP

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <el-tel-input v-model="telNumber" @input-details="handleElTelInputDetails" default-country="CA" :preferred-countries="['CA','US','CN']"></el-tel-input>
+    <el-tel-input v-model="telNumber" @input-details="handleElTelInputDetails" default-country="CA" :preferred-countries="['CA','US','CN']" :detect-country-code-from-ip="false"></el-tel-input>
     <code>
       {{ this.telNumberDetails }}
     </code>

--- a/src/components/ElTelInput.vue
+++ b/src/components/ElTelInput.vue
@@ -88,6 +88,10 @@ export default {
     popperClass: {
       type: String,
       default: ''
+    },
+    detectCountryCodeFromIp: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -103,9 +107,11 @@ export default {
     ElFlaggedLabel
   },
   async created() {
-    const response = (await axios.get('https://ipinfo.io/json').catch(() => {})) || { data: { country: 'US' } };
-    if (response && response.data && response.data.country) {
-      this.handleCountryCodeInput(response.data.country);
+    if (this.detectCountryCodeFromIp) {
+      const response = (await axios.get('https://ipinfo.io/json').catch(() => {})) || { data: { country: 'US' } };
+      if (response && response.data && response.data.country) {
+        this.handleCountryCodeInput(response.data.country);
+      }
     }
   },
   computed: {


### PR DESCRIPTION
For using the input in places where the value is already set, this causes issues with the country code getting replaced with the one from the user IP